### PR TITLE
add support for Module::Build #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 /t/test-data/dzil_module/build_dir
+/t/test-data/module-build_module/_build
+/t/test-data/module-build_module/build_dir
+/t/test-data/module-build_module/MANIFEST*
+/t/test-data/module-build_module/Build
+

--- a/bin/build-dist
+++ b/bin/build-dist
@@ -15,6 +15,17 @@ elif [[ -e minil.toml ]]; then
     # shellcheck disable=SC2012
     DIR=$(ls -td -- */ | head -n 1 | cut -d'/' -f1)
     mv "$DIR" build_dir
+elif [[ -e Build.PL ]]; then
+    rm -rf "$BUILD_DIR"
+    perl Build.PL
+    ./Build clean
+    ./Build manifest
+    ./Build distdir
+
+    # Module::Build does not support a build directory, so we have to find
+    # the last created dir and use that.
+    DIR="$(perl -MModule::Build -e'print Module::Build->resume->dist_dir;')"
+    mv "$DIR" $BUILD_DIR
 fi
 
 exit 0

--- a/t/module_build_module.bats
+++ b/t/module_build_module.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+PATH="$PATH:../../../bin"
+
+setup() {
+  cd t/test-data/module-build_module
+}
+
+@test "Build.PL cpan-install-dist-deps" {
+  run cpan-install-build-deps
+  [ "$status" -eq 0 ]
+}
+
+@test "Build.PL build-dist" {
+  run build-dist
+  [ "$status" -eq 0 ]
+}
+
+@test "Build.PL test-dist" {
+  run cd build_dir && test-dist
+  [ "$status" -eq 0 ]
+}
+
+@test "Build.PL auto-build-and-test-dist" {
+  GITHUB_ACTIONS=${GITHUB_ACTIONS:=''}
+  if [[ $GITHUB_ACTIONS=true ]]; then
+    skip "Tricky to test under CI"
+  fi
+  run rm -rf build_dir && bash auto-build-and-test-dist && rm -rf build_dir
+  [ "$status" -eq 0 ]
+}

--- a/t/test-data/module-build_module/Build.PL
+++ b/t/test-data/module-build_module/Build.PL
@@ -1,0 +1,5 @@
+use Module::Build;
+Module::Build->new(
+  module_name => 'Acme::Helpers',
+  license     => 'perl',
+)->create_build_script;

--- a/t/test-data/module-build_module/lib/Acme/Helpers.pm
+++ b/t/test-data/module-build_module/lib/Acme/Helpers.pm
@@ -1,0 +1,14 @@
+package Acme::Helpers;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.01';
+
+sub true {
+    return 1;
+}
+
+1;
+
+# ABSTRACT: turns baubles into trinkets

--- a/t/test-data/module-build_module/t/load.t
+++ b/t/test-data/module-build_module/t/load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Acme::Helpers ();
+ok( Acme::Helpers::true() );
+
+done_testing();

--- a/t/test-data/module-build_module/xt/load.t
+++ b/t/test-data/module-build_module/xt/load.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Acme::Helpers ();
+ok( Acme::Helpers::true() );
+
+done_testing();


### PR DESCRIPTION
I _think_ I did the right thing here. I tested it locally with bats. I don't know how well installing deps will work, because it seems Build.PL does not create a cpanfile automatically. `cpanm --installdeps` can work with Build.PL, but we don't use it. `cpm` doesn't seem to support it installing deps without a cpanfile.

It also leaves behind some files in the test build directory that don't get cleaned up with `./Build clean`. I added those to gitignore, but I'm not sure if they need to be removed in any other way.

Closes #6 