### PR TITLE
install dependencies from Module::Build

### DIFF
--- a/bin/cpan-install-dist-deps
+++ b/bin/cpan-install-dist-deps
@@ -5,3 +5,9 @@ set -eux
 if [[ -e cpanfile ]];then
     cpm install -g --cpanfile cpanfile --with-recommends --with-suggests --show-build-log-on-failure "$@"
 fi
+
+if [[ -e Build.PL ]]; then
+    # This will install both build and dist deps
+    perl Build.PL
+    PERL_MM_USE_DEFAULT=1 ./Build installdeps --cpan_client 'cpm install -g --show-build-log-on-failure' || true
+fi


### PR DESCRIPTION
cpm only supports cpanfile, but not reading a Build.PL script like cpanm does, so we need to run it and use the build-in installation. Leon T tells me this is not the best way of doing it, but he concurs it's the only way unless cpm supports this format, or we use cpanm.

I forgot this bit in my previous PR. My apologies.