### PR TITLE
Expose tester helpers as github actions as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ job:
     ...
     steps:
 	  ...
+      - uses: perl-actions/ci-perl-tester-helpers/install-test-helper-deps@main
       - uses: perl-actions/ci-perl-tester-helpers/cpan-install-build-deps@main
       - uses: perl-actions/ci-perl-tester-helpers/build-dist@main
       - uses: perl-actions/ci-perl-tester-helpers/cpan-install-dist-deps@main
@@ -62,6 +63,7 @@ job:
         env:
           AUTHOR_TESTING: 1
 ```
+
 ## perl-actions/ci-perl-tester-helpers/build-dist@master
 
 Build your distribution detecting what framework you are using.
@@ -73,6 +75,12 @@ Install build dependencies (eg: dzil modules referenced in your `dist.ini`)
 ## perl-actions/ci-perl-tester-helpers/cpan-install-dist-deps@master
 
 Install dependencies of your distribution.
+
+## perl-actions/ci-perl-tester-helpers/install-helpers-deps@master
+
+Install dependencies required by ci-perl-tester-helpers
+
+- `cpm` - required version min `0.997014`
 
 ## perl-actions/ci-perl-tester-helpers/test-dist@master
 

--- a/README.md
+++ b/README.md
@@ -45,3 +45,40 @@ curl https://raw.githubusercontent.com/perl-actions/ci-perl-tester-helpers/maste
 # Linting
 
 You can lint this project locally via `precious lint --all`
+
+# Github Actions
+
+Commands are also available as github actions:
+```
+job:
+  linux:
+    ...
+    steps:
+	  ...
+      - uses: perl-actions/ci-perl-tester-helpers/cpan-install-build-deps@main
+      - uses: perl-actions/ci-perl-tester-helpers/build-dist@main
+      - uses: perl-actions/ci-perl-tester-helpers/cpan-install-dist-deps@main
+      - uses: perl-actions/ci-perl-tester-helpers/test-dist@main
+        env:
+          AUTHOR_TESTING: 1
+```
+## perl-actions/ci-perl-tester-helpers/build-dist@master
+
+Build your distribution detecting what framework you are using.
+
+## perl-actions/ci-perl-tester-helpers/cpan-install-build-deps@master
+
+Install build dependencies (eg: dzil modules referenced in your `dist.ini`)
+
+## perl-actions/ci-perl-tester-helpers/cpan-install-dist-deps@master
+
+Install dependencies of your distribution.
+
+## perl-actions/ci-perl-tester-helpers/test-dist@master
+
+Tests your distribution using `prove` with `--state save`.
+
+Recognizes env variables:
+
+- `AUTHOR_TESTING`
+  If set to `1`, includes tests in `xt` directory (if available)

--- a/build-dist/action.yml
+++ b/build-dist/action.yml
@@ -1,0 +1,8 @@
+---
+name: 'Build distribution'
+description: 'Build distribution, automatically detecting how'
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/../bin/build-dist
+      shell: bash

--- a/cpan-install-build-deps/action.yml
+++ b/cpan-install-build-deps/action.yml
@@ -1,0 +1,8 @@
+---
+name: 'Install build dependencies from CPAN'
+description: 'Install build dependencies from CPAN'
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/../bin/cpan-install-build-deps
+      shell: bash

--- a/cpan-install-dist-deps/action.yml
+++ b/cpan-install-dist-deps/action.yml
@@ -1,0 +1,8 @@
+---
+name: 'Install distribution dependencies from CPAN'
+description: 'Install distribution dependencies from CPAN'
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/../bin/cpan-install-dist-deps
+      shell: bash

--- a/install-test-helper-deps/action.yml
+++ b/install-test-helper-deps/action.yml
@@ -1,0 +1,10 @@
+---
+name: 'Install test helpers dependencies'
+description: 'Install test helpers dependencies'
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        # we need cpm with --metafile support
+        wget https://raw.githubusercontent.com/skaji/cpm/main/cpm > /usr/local/bin/cpm

--- a/test-dist/action.yml
+++ b/test-dist/action.yml
@@ -1,0 +1,8 @@
+---
+name: 'Test distribution'
+description: 'Test distribution'
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/../bin/test-dist
+      shell: bash


### PR DESCRIPTION
so even people who doesn't use `perldocker/perl-tester` images can use these tools

