### PR TITLE
Fix cpm installation: adds missing execution permissions

### DIFF
--- a/install-test-helper-deps/action.yml
+++ b/install-test-helper-deps/action.yml
@@ -8,3 +8,4 @@ runs:
       run: |
         # we need cpm with --metafile support
         wget https://raw.githubusercontent.com/skaji/cpm/main/cpm > /usr/local/bin/cpm
+        chmod +x /usr/local/bin/cpm


### PR DESCRIPTION
Without it the pipeline is failed:
`/home/runner/work/_actions/perl-actions/ci-perl-tester-helpers/main/cpan-install-dist-deps/../bin/cpan-install-dist-deps: line 25: /usr/local/bin/cpm: Permission denied`
https://github.com/und3f/crypt-ssss/actions/runs/16144137779/job/45558417958